### PR TITLE
Make quiet mode work

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,7 @@ module.exports = function (opts) {
     }, function (cb) {
         if(opts.quiet) {
             cb();
+            return;
         }
         var msg = 'Minified ' + totalFiles + ' ';
 


### PR DESCRIPTION
Currently, "quiet mode" still prints the log message, and calls the callback function a second time.